### PR TITLE
load polyfill for component scoping

### DIFF
--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -20,6 +20,7 @@
   </head>
   <body>
     <we-app></we-app>
+    <script src="../../node_modules/@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min.js"></script>
     <script type="module" src="./src/we-app.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
this seems to fix a bug that was giving an error like:
```
Unhandled Promise Rejection: Error: Failed to execute 'define' on 'CustomElementRegistry': the name "todo-applet" has already been used with this registry
```