### PR TITLE
Update feed to communicate important updates and bugs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # platform: [windows-2019]
+        platform: [windows-2019]
         # platform: [macos-11]
-        platform: [windows-2019, macos-11, ubuntu-22.04]
+        # platform: [windows-2019, macos-11, ubuntu-22.04]
         # platform: [windows-2019, ubuntu-22.04]
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
@@ -95,15 +95,15 @@ jobs:
           yarn build:win || yarn build:win || yarn build:win || yarn build:win || yarn build:win
           ls dist
 
-          # Sign the .exe file
-          dotnet tool install --global --version 4.0.1 AzureSignTool
-          echo "sha512 before code signing"
-          CertUtil -hashfile "dist/org.lightningrodlabs.we-electron-alpha-${{ steps.version.outputs.APP_VERSION }}-setup.exe" SHA512
-          AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v "dist/org.lightningrodlabs.we-electron-alpha-${{ steps.version.outputs.APP_VERSION }}-setup.exe"
-          echo "sha512 after code signing"
-          CertUtil -hashfile "dist/org.lightningrodlabs.we-electron-alpha-${{ steps.version.outputs.APP_VERSION }}-setup.exe" SHA512
+          # # Sign the .exe file
+          # dotnet tool install --global --version 4.0.1 AzureSignTool
+          # echo "sha512 before code signing"
+          # CertUtil -hashfile "dist/org.lightningrodlabs.we-electron-alpha-${{ steps.version.outputs.APP_VERSION }}-setup.exe" SHA512
+          # AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v "dist/org.lightningrodlabs.we-electron-alpha-${{ steps.version.outputs.APP_VERSION }}-setup.exe"
+          # echo "sha512 after code signing"
+          # CertUtil -hashfile "dist/org.lightningrodlabs.we-electron-alpha-${{ steps.version.outputs.APP_VERSION }}-setup.exe" SHA512
 
-          # Overwrite the latest.yml one with one containing the sha512 of the code signed .exe file
-          node ./scripts/latest-yaml.js
-          gh release upload "latest.yml" "latest.yml" --clobber
-          gh release upload "we-alpha-v${{ steps.version.outputs.APP_VERSION }}" "dist/org.lightningrodlabs.we-electron-alpha-${{ steps.version.outputs.APP_VERSION }}-setup.exe" --clobber
+          # # Overwrite the latest.yml one with one containing the sha512 of the code signed .exe file
+          # node ./scripts/latest-yaml.js
+          # gh release upload "latest.yml" "latest.yml" --clobber
+          # gh release upload "we-alpha-v${{ steps.version.outputs.APP_VERSION }}" "dist/org.lightningrodlabs.we-electron-alpha-${{ steps.version.outputs.APP_VERSION }}-setup.exe" --clobber

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-2019]
+        # platform: [windows-2019]
         # platform: [macos-11]
-        # platform: [windows-2019, macos-11, ubuntu-22.04]
+        platform: [windows-2019, macos-11, ubuntu-22.04]
         # platform: [windows-2019, ubuntu-22.04]
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13

--- a/news.json
+++ b/news.json
@@ -1,0 +1,8 @@
+{
+  "0.11.x": [
+    {
+      "type": "bug",
+      "message": "Moss versions 0.11.9 and 0.11.10 contain a bug that prevents automatic updates from succeeding on macOS and Windows. To resolve the issue, manually download and install the latest version of Moss from https://theweave.social/moss"
+    }
+  ]
+}

--- a/news.json
+++ b/news.json
@@ -1,7 +1,8 @@
 {
   "0.11.x": [
     {
-      "type": "bug",
+      "type": "🐞 Bug",
+      "timestamp": 1713645257319,
       "message": "Moss versions 0.11.9 and 0.11.10 contain a bug that prevents automatic updates from succeeding on macOS and Windows. To resolve the issue, manually download and install the latest version of Moss from https://theweave.social/moss"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.lightningrodlabs.we-electron-alpha",
-  "version": "0.11.9-alpha",
+  "version": "0.11.11",
   "private": true,
   "description": "Moss (Alpha)",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.lightningrodlabs.we-electron-alpha",
-  "version": "0.11.10",
+  "version": "0.11.9-alpha",
   "private": true,
   "description": "Moss (Alpha)",
   "main": "./out/main/index.js",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,7 +32,7 @@ import { SCREEN_OR_WINDOW_SELECTED, WeEmitter } from './weEmitter';
 import { HolochainManager } from './holochainManager';
 import { setupLogs } from './logs';
 import { DEFAULT_APPS_DIRECTORY, ICONS_DIRECTORY } from './paths';
-import { emitToWindow, setLinkOpenHandlers } from './utils';
+import { breakingVersion, emitToWindow, setLinkOpenHandlers } from './utils';
 import { createHappWindow } from './windows';
 import { APPSTORE_APP_ID, AppHashes } from './sharedTypes';
 import { nanoid } from 'nanoid';
@@ -956,7 +956,7 @@ app.whenReady().then(async () => {
       // We only install semver compatible updates
       if (
         updateCheckResult &&
-        // breakingVersion(updateCheckResult.updateInfo.version) === breakingVersion(appVersion) &&
+        breakingVersion(updateCheckResult.updateInfo.version) === breakingVersion(appVersion) &&
         semver.gt(updateCheckResult.updateInfo.version, appVersion)
       ) {
         const userDecision = await dialog.showMessageBox({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,7 +32,7 @@ import { SCREEN_OR_WINDOW_SELECTED, WeEmitter } from './weEmitter';
 import { HolochainManager } from './holochainManager';
 import { setupLogs } from './logs';
 import { DEFAULT_APPS_DIRECTORY, ICONS_DIRECTORY } from './paths';
-import { breakingVersion, emitToWindow, setLinkOpenHandlers } from './utils';
+import { emitToWindow, setLinkOpenHandlers } from './utils';
 import { createHappWindow } from './windows';
 import { APPSTORE_APP_ID, AppHashes } from './sharedTypes';
 import { nanoid } from 'nanoid';
@@ -956,7 +956,7 @@ app.whenReady().then(async () => {
       // We only install semver compatible updates
       if (
         updateCheckResult &&
-        breakingVersion(updateCheckResult.updateInfo.version) === breakingVersion(appVersion) &&
+        // breakingVersion(updateCheckResult.updateInfo.version) === breakingVersion(appVersion) &&
         semver.gt(updateCheckResult.updateInfo.version, appVersion)
       ) {
         const userDecision = await dialog.showMessageBox({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,7 +32,7 @@ import { SCREEN_OR_WINDOW_SELECTED, WeEmitter } from './weEmitter';
 import { HolochainManager } from './holochainManager';
 import { setupLogs } from './logs';
 import { DEFAULT_APPS_DIRECTORY, ICONS_DIRECTORY } from './paths';
-import { breakingVersion, emitToWindow, setLinkOpenHandlers } from './utils';
+import { emitToWindow, setLinkOpenHandlers } from './utils';
 import { createHappWindow } from './windows';
 import { APPSTORE_APP_ID, AppHashes } from './sharedTypes';
 import { nanoid } from 'nanoid';
@@ -956,7 +956,7 @@ app.whenReady().then(async () => {
       // We only install semver compatible updates
       if (
         updateCheckResult &&
-        breakingVersion(updateCheckResult.updateInfo.version) === breakingVersion(appVersion) &&
+        // breakingVersion(updateCheckResult.updateInfo.version) === breakingVersion(appVersion) &&
         semver.gt(updateCheckResult.updateInfo.version, appVersion)
       ) {
         const userDecision = await dialog.showMessageBox({
@@ -969,7 +969,9 @@ app.whenReady().then(async () => {
         });
         if (userDecision.response === 1) {
           // downloading means that with the next start of the application it's automatically going to be installed
+          autoUpdater.on('update-downloaded', () => autoUpdater.quitAndInstall());
           await autoUpdater.downloadUpdate();
+
           // let options: Electron.RelaunchOptions = {
           //   args: process.argv,
           // };

--- a/src/renderer/src/elements/main-dashboard.ts
+++ b/src/renderer/src/elements/main-dashboard.ts
@@ -58,7 +58,7 @@ import { openViewsContext } from '../layout/context.js';
 import { AppOpenViews } from '../layout/types.js';
 import { decodeContext, getAllIframes, stringifyWal } from '../utils.js';
 import { getAppVersion } from '../electron-api.js';
-import { UpdateFeed, UpdateFeedMessage } from '../types.js';
+import { UpdateFeedMessage } from '../types.js';
 
 type OpenTab =
   | {

--- a/src/renderer/src/elements/main-dashboard.ts
+++ b/src/renderer/src/elements/main-dashboard.ts
@@ -58,6 +58,7 @@ import { openViewsContext } from '../layout/context.js';
 import { AppOpenViews } from '../layout/types.js';
 import { decodeContext, getAllIframes, stringifyWal } from '../utils.js';
 import { getAppVersion } from '../electron-api.js';
+import { UpdateFeed, UpdateFeedMessage } from '../types.js';
 
 type OpenTab =
   | {
@@ -136,6 +137,9 @@ export class MainDashboard extends LitElement {
 
   @state()
   _selectedTab: TabInfo | undefined;
+
+  @state()
+  _updateFeed: Array<UpdateFeedMessage> = [];
 
   _dashboardState = new StoreSubscriber(
     this,
@@ -523,6 +527,18 @@ export class MainDashboard extends LitElement {
     // }, 10000);
 
     this.appVersion = await getAppVersion();
+
+    // Fetch Moss update feed
+    try {
+      // TODO change URL to point to main branch before merging
+      const response = await fetch(
+        'https://raw.githubusercontent.com/lightningrodlabs/we/feat/update-feed/news.json',
+      );
+      const updateFeed = await response.json();
+      this._updateFeed = updateFeed['0.11.x'];
+    } catch (e) {
+      console.warn('Failed to fetch update feed: ', e);
+    }
   }
 
   openClipboard() {
@@ -975,6 +991,7 @@ export class MainDashboard extends LitElement {
           <welcome-view
             id="welcome-view"
             @click=${(e) => e.stopPropagation()}
+            .updateFeed=${this._updateFeed}
             style="${this._dashboardState.value.viewType === 'personal'
               ? 'display: flex; flex: 1;'
               : 'display: none;'}${this._drawerResizing

--- a/src/renderer/src/layout/views/welcome-view.ts
+++ b/src/renderer/src/layout/views/welcome-view.ts
@@ -290,12 +290,29 @@ export class WelcomeView extends LitElement {
 
             <!-- Moss Update Feed -->
 
-            <div></div>
-
             <div
               class="column"
-              style="align-items: center; display:flex; flex: 1; margin-top: 40px;"
-            ></div>
+              style="align-items: center; display:flex; flex: 1; margin-top: 40px; color: white;"
+            >
+              <h1>🏄 &nbsp;&nbsp;Moss Updates&nbsp;&nbsp; 🚧</h1>
+              <span style="margin-top: 10px; margin-bottom: 30px; font-size: 18px;"
+                >Thank you for surfing the edge of
+                <a href="https://theweave.social" style="color: yellow;">the Weave</a>. Below are
+                relevant updates for early weavers.</span
+              >
+              <div class="column">
+                ${this.updateFeed.length === 0
+                  ? html`No big waves lately...`
+                  : this.updateFeed.map(
+                      (message) => html`
+                        <div class="update-feed-el">
+                          <div class="update-type">${message.type}</div>
+                          ${message.message}
+                        </div>
+                      `,
+                    )}
+              </div>
+            </div>
           </div>
         `;
     }
@@ -371,6 +388,31 @@ export class WelcomeView extends LitElement {
 
       .disclaimer-btn:hover {
         background: linear-gradient(#f2f98e, #b6c027);
+      }
+
+      .update-feed-el {
+        max-width: 800px;
+        position: relative;
+        padding: 20px;
+        padding-top: 40px;
+        border-radius: 10px;
+        background: rgba(22, 35, 17, 1.0);
+        margin: 5px;
+        border: 2px solid
+        cursor: pointer;
+        color: #fff;
+        border: 2px solid rgba(96, 124, 4, .50);
+        transition: all .25s ease;
+        font-size: 18px;
+        line-height: 1.4;
+      }
+
+      .update-type {
+        font-size: 20px;
+        position: absolute;
+        top: 7px;
+        right: 12px;
+        font-weight: bold;
       }
 
       .feed {

--- a/src/renderer/src/layout/views/welcome-view.ts
+++ b/src/renderer/src/layout/views/welcome-view.ts
@@ -22,6 +22,7 @@ import { MossStore } from '../../moss-store.js';
 import { toPromise } from '@holochain-open-dev/stores';
 import { encodeHashToBase64 } from '@holochain/client';
 import { UpdateFeedMessage } from '../../types.js';
+import TimeAgo from 'javascript-time-ago';
 
 enum WelcomePageView {
   Main,
@@ -44,6 +45,8 @@ export class WelcomeView extends LitElement {
 
   @property()
   updateFeed!: Array<UpdateFeedMessage>;
+
+  timeAgo = new TimeAgo('en-US');
 
   // _notificationFeed = new StoreSubscriber(
   //   this,
@@ -306,6 +309,7 @@ export class WelcomeView extends LitElement {
                   : this.updateFeed.map(
                       (message) => html`
                         <div class="update-feed-el">
+                          <div class="update-date">${this.timeAgo.format(message.timestamp)}</div>
                           <div class="update-type">${message.type}</div>
                           ${message.message}
                         </div>
@@ -394,7 +398,7 @@ export class WelcomeView extends LitElement {
         max-width: 800px;
         position: relative;
         padding: 20px;
-        padding-top: 40px;
+        padding-top: 45px;
         border-radius: 10px;
         background: rgba(22, 35, 17, 1.0);
         margin: 5px;
@@ -405,6 +409,14 @@ export class WelcomeView extends LitElement {
         transition: all .25s ease;
         font-size: 18px;
         line-height: 1.4;
+      }
+
+      .update-date {
+        position: absolute;
+        font-size: 14px;
+        top: 12px;
+        left: 20px;
+        opacity: 0.6;
       }
 
       .update-type {

--- a/src/renderer/src/layout/views/welcome-view.ts
+++ b/src/renderer/src/layout/views/welcome-view.ts
@@ -1,10 +1,12 @@
 import { html, LitElement, css } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { localized, msg } from '@lit/localize';
 
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
+import SlDialog from '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 
 import { wrapPathInSvg } from '@holochain-open-dev/elements';
 import { mdiAccountLockOpen, mdiAccountMultiplePlus, mdiAlert, mdiViewGridPlus } from '@mdi/js';
@@ -17,8 +19,9 @@ import '../../applets/elements/applet-title.js';
 import { mossStoreContext } from '../../context.js';
 import { consume } from '@lit/context';
 import { MossStore } from '../../moss-store.js';
-import { StoreSubscriber, toPromise } from '@holochain-open-dev/stores';
+import { toPromise } from '@holochain-open-dev/stores';
 import { encodeHashToBase64 } from '@holochain/client';
+import { UpdateFeedMessage } from '../../types.js';
 
 enum WelcomePageView {
   Main,
@@ -36,11 +39,17 @@ export class WelcomeView extends LitElement {
   @state()
   notificationsLoading = true;
 
-  _notificationFeed = new StoreSubscriber(
-    this,
-    () => this._mossStore.notificationFeed(),
-    () => [this._mossStore],
-  );
+  @query('#disclaimer-dialog')
+  _displaimerDialog!: SlDialog;
+
+  @property()
+  updateFeed!: Array<UpdateFeedMessage>;
+
+  // _notificationFeed = new StoreSubscriber(
+  //   this,
+  //   () => this._mossStore.notificationFeed(),
+  //   () => [this._mossStore],
+  // );
 
   async firstUpdated() {
     try {
@@ -124,13 +133,84 @@ export class WelcomeView extends LitElement {
     `;
   }
 
+  renderDisclaimerDialog() {
+    return html` <sl-dialog
+      id="disclaimer-dialog"
+      style="--width: 900px; --sl-panel-background-color: #f0f59d;"
+      no-header
+    >
+      <div class="disclaimer">
+        <div
+          class="row"
+          style="align-items: center; font-size: 30px; justify-content: center; margin-bottom: 28px;"
+        >
+          <sl-icon .src=${wrapPathInSvg(mdiAlert)}></sl-icon>
+          <span style="margin-left: 5px;">Moss is Alpha Software</span>
+        </div>
+        <div style="max-width: 800px; margin-top: 20px; font-size: 20px;">
+          Moss development is in alpha stage. It is best suited for
+          <b>adventurous early-adopters</b>. Please
+          <b>don't expect it to be stable or bug free!</b> That said, we use Moss in-house daily for
+          doing our work on Moss itself, using the tools for planning, chatting, video calls, etc.
+          <br /><br />
+          We <b>export data from our Tools/Applets frequently</b> and sometimes have to recover from
+          these backups. We recommend you do the same. <br /><br />
+          What you can/should expect:
+          <ul>
+            <li>
+              If Moss offers you to install an update on startup, this update will always be
+              compatible with your current version of Moss. Compatible versions of Moss are
+              indicated by the first non-zero number in the version name. If you are using Moss
+              0.11.5 it is compatible with Moss 0.11.8 but it is <i>not</i> compatible with Moss
+              0.12.0.
+            </li>
+            <li>
+              You can <b>not</b> expect your current version of Moss to receive ongoing bugfixes
+              until we explicitly say so. That said, we are targeting to release a version "Moss
+              Sprout" in the coming months that will receive support in the form of bugfixes and UI
+              improvements for a defined period of time. Until that point there will be a succession
+              of breaking releases of Moss (0.12.x, 0.13.x, ...) that are going to be incompatible
+              between each other, meaning that if you decide to go to a newer version, you will not
+              be able to access or join groups created in the previous version.
+            </li>
+            <li>
+              As we are developing Moss and the Weave, we are also continually trying to find the
+              most suitable naming and terminology. Expect therefore names of things to keep
+              changing in the near future. One notable change is likely going to be "Applet" to
+              "Tool".
+            </li>
+          </ul>
+        </div>
+      </div>
+    </sl-dialog>`;
+  }
+
   render() {
     switch (this.view) {
       case WelcomePageView.Main:
         return html`
+          ${this.renderDisclaimerDialog()}
           <div class="column" style="align-items: center; flex: 1; overflow: auto;">
-            <div class="row" flex-wrap: wrap;">
-            <button
+            <div
+              class="disclaimer-btn"
+              tabindex="0"
+              @click=${() => this._displaimerDialog.show()}
+              @keypress=${(e: KeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  this._displaimerDialog.show();
+                }
+              }}
+            >
+              <div
+                class="row"
+                style="align-items: center; font-size: 26px; justify-content: center;"
+              >
+                <sl-icon .src=${wrapPathInSvg(mdiAlert)}></sl-icon>
+                <span style="margin-left: 5px;">Disclaimer</span>
+              </div>
+            </div>
+            <div class="row" style="flex-wrap: wrap; margin-top: 80px;">
+              <button
                 class="btn"
                 @click=${(_e) =>
                   this.dispatchEvent(
@@ -208,48 +288,14 @@ export class WelcomeView extends LitElement {
               </button>
             </div>
 
-            <!-- Notification Feed -->
+            <!-- Moss Update Feed -->
 
-            <div class="column" style="align-items: center; display:flex; flex: 1; margin-top: 40px;">
-              <div class="disclaimer">
-                <div class="row" style="align-items: center; font-size: 30px;">
-                  <sl-icon .src=${wrapPathInSvg(mdiAlert)}></sl-icon>
-                  <span style="margin-left: 5px;">Moss is Alpha Software</span>
-                </div>
-                <div style="max-width: 800px; margin-top: 20px; font-size: 20px;">
-                  Moss development is in alpha stage. It is best suited for adventurous early-adopters.
-                  Please don't expect it to be stable or bug free! That said, we use Moss in-house daily
-                  for doing our work on Moss itself, using the tools for planning, chatting, video calls, etc.
-                  <br><br>
-                  We export data from our Tools/Applets frequently and sometimes have to recover from these backups.
-                  We recommend you do the same.
-                  <br><br>
-                  What you can/should expect:
-                  <ul>
-                    <li>
-                      If Moss offers you to install an update on startup, this update will always be compatible with your
-                      current version of Moss. Compatible versions of Moss are indicated by the first non-zero number in the version
-                      name. If you are using Moss 0.11.5 it is compatible with Moss 0.11.8 but it is <i>not</i> compatible
-                      with Moss 0.12.0.
-                    </li>
-                    <li>
-                      You can <b>not</b> expect your current version of Moss to receive ongoing bugfixes until we explicitly say so.
-                      That said, we are targeting to release a version "Moss Sprout" in the coming months
-                      that will receive support in the form of bugfixes and UI improvements for a defined period of time.
-                      Until that point there will be a succession of breaking releases of Moss (0.12.x, 0.13.x, ...) that
-                      are going to be incompatible between each other, meaning that if you decide to go to a newer version,
-                      you will not be able to access or join groups created in the previous version.
-                    </li>
-                    <li>
-                      As we are developing Moss and the Weave, we are also continually trying to find the most suitable
-                      naming and terminology. Expect therefore names of things to keep changing in
-                      the near future. One notable change is likely going to be "Applet" to "Tool".
-                    </li>
+            <div></div>
 
-                  </ul>
-                </div>
-              </div>
-            </div>
+            <div
+              class="column"
+              style="align-items: center; display:flex; flex: 1; margin-top: 40px;"
+            ></div>
           </div>
         `;
     }
@@ -300,12 +346,31 @@ export class WelcomeView extends LitElement {
       }
 
       .disclaimer {
-        color: #fff78e;
-        border: 2px solid #fff78e;
+        color: #002a00;
+        /* border: 2px solid #fff78e; */
         padding: 20px;
         border-radius: 20px;
-        background: #fff78e1f;
+        /* background: #fff78e1f; */
         line-height: 1.2;
+      }
+
+      .disclaimer-btn {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        /* background: #f4fb86; */
+        background: linear-gradient(#e0e871, #acb520);
+        border-radius: 12px;
+        display: flex;
+        align-items: center;
+        flex-direction: row;
+        padding: 10px;
+        box-shadow: 0 0 2px 2px #202020;
+        cursor: pointer;
+      }
+
+      .disclaimer-btn:hover {
+        background: linear-gradient(#f2f98e, #b6c027);
       }
 
       .feed {

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -138,3 +138,15 @@ export type MessageContentPart =
       type: 'agent';
       pubkey: AgentPubKeyB64;
     };
+
+/**
+ * Notification feed to end-users
+ */
+export type UpdateFeed = {
+  [key: string]: Array<UpdateFeedMessage>;
+};
+
+export type UpdateFeedMessage = {
+  type: string;
+  message: string;
+};

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -148,5 +148,6 @@ export type UpdateFeed = {
 
 export type UpdateFeedMessage = {
   type: string;
+  timestamp: number;
   message: string;
 };


### PR DESCRIPTION
With the broken auto-updates on Windows and macOS in versions 0.11.9 and 0.11.10 I realized that - given that we start having users - it's important that we have a way to communicate important updates or bugs with workarounds to our users.
This PR is an attempt for a simple solution for this.
It fetches notifications from the `news.json` file from the we repository and displays them on the main page in Moss.