### PR TITLE
added logic to allow for null hash

### DIFF
--- a/example/ui/index.html
+++ b/example/ui/index.html
@@ -84,15 +84,15 @@
                 hrl: [dnaHash, actionHash],
               }));
           },
-          getAssetInfo: async (appletClient, wal, recordLocation) => {
-            console.log('Got getAssetInfo request: ', wal, recordLocation);
-            switch (recordLocation.roleName) {
+          getAssetInfo: async (appletClient, wal, recordInfo) => {
+            console.log('Got getAssetInfo request: ', wal, recordInfo);
+            switch (recordInfo.roleName) {
               case 'forum':
-                switch (recordLocation.integrityZomeName) {
+                switch (recordInfo.integrityZomeName) {
                   case 'posts_integrity':
-                    switch (recordLocation.entryType) {
+                    switch (recordInfo.entryType) {
                       case 'post':
-                        const postsClient = new PostsClient(appletClient, recordLocation.roleName);
+                        const postsClient = new PostsClient(appletClient, recordInfo.roleName);
                         const post = await postsClient.getPost(wal.hrl[1]);
                         if (!post) return undefined;
                         return {
@@ -100,13 +100,13 @@
                           icon_src: wrapPathInSvg(mdiPost),
                         };
                       default:
-                        throw new Error(`Unknown entry type ${recordLocation.entryType}.`);
+                        throw new Error(`Unknown entry type ${recordInfo.entryType}.`);
                     }
                   default:
-                    throw new Error(`Unknown zome '${recordLocation.integrityZomeName}'.`);
+                    throw new Error(`Unknown zome '${recordInfo.integrityZomeName}'.`);
                 }
               default:
-                throw new Error(`Unknown role name '${recordLocation.roleName}'.`);
+                throw new Error(`Unknown role name '${recordInfo.roleName}'.`);
             }
           },
         };

--- a/example/ui/index.html
+++ b/example/ui/index.html
@@ -84,14 +84,15 @@
                 hrl: [dnaHash, actionHash],
               }));
           },
-          getAssetInfo: async (appletClient, roleName, integrityZomeName, entryType, wal) => {
-            switch (roleName) {
+          getAssetInfo: async (appletClient, wal, recordLocation) => {
+            console.log('Got getAssetInfo request: ', wal, recordLocation);
+            switch (recordLocation.roleName) {
               case 'forum':
-                switch (integrityZomeName) {
+                switch (recordLocation.integrityZomeName) {
                   case 'posts_integrity':
-                    switch (entryType) {
+                    switch (recordLocation.entryType) {
                       case 'post':
-                        const postsClient = new PostsClient(appletClient, roleName);
+                        const postsClient = new PostsClient(appletClient, recordLocation.roleName);
                         const post = await postsClient.getPost(wal.hrl[1]);
                         if (!post) return undefined;
                         return {
@@ -99,13 +100,13 @@
                           icon_src: wrapPathInSvg(mdiPost),
                         };
                       default:
-                        throw new Error(`Unknown entry type ${entryType}.`);
+                        throw new Error(`Unknown entry type ${recordLocation.entryType}.`);
                     }
                   default:
-                    throw new Error(`Unknown zome '${integrityZomeName}'.`);
+                    throw new Error(`Unknown zome '${recordLocation.integrityZomeName}'.`);
                 }
               default:
-                throw new Error(`Unknown role name '${roleName}'.`);
+                throw new Error(`Unknown role name '${recordLocation.roleName}'.`);
             }
           },
         };

--- a/example/ui/src/example-applet.ts
+++ b/example/ui/src/example-applet.ts
@@ -82,35 +82,41 @@ export class ExampleApplet extends LitElement {
           case 'block':
             throw new Error('Block view is not implemented.');
           case 'asset':
-            switch (this.weaveClient.renderInfo.view.roleName) {
-              case 'forum':
-                switch (this.weaveClient.renderInfo.view.integrityZomeName) {
-                  case 'posts_integrity':
-                    switch (this.weaveClient.renderInfo.view.entryType) {
-                      case 'post':
-                        return html`
-                          <posts-context .store=${this.postsStore}>
-                            <attachments-context .store=${this.attachmentsStore}>
-                              <post-detail
-                                .postHash=${this.weaveClient.renderInfo.view.wal.hrl[1]}
-                              ></post-detail>
-                            </attachments-context>
-                          </posts-context>
-                        `;
-                      default:
-                        throw new Error(
-                          `Unknown entry type ${this.weaveClient.renderInfo.view.entryType}.`
-                        );
-                    }
-                  default:
-                    throw new Error(
-                      `Unknown zome '${this.weaveClient.renderInfo.view.integrityZomeName}'.`
-                    );
-                }
-              default:
-                throw new Error(
-                  `Unknown role name '${this.weaveClient.renderInfo.view.roleName}'.`
-                );
+            if (!this.weaveClient.renderInfo.view.recordLocation) {
+              throw new Error(
+                'The example applet does not implement asset views pointing to DNAs instead of Records.'
+              );
+            } else {
+              switch (this.weaveClient.renderInfo.view.recordLocation.roleName) {
+                case 'forum':
+                  switch (this.weaveClient.renderInfo.view.recordLocation.integrityZomeName) {
+                    case 'posts_integrity':
+                      switch (this.weaveClient.renderInfo.view.recordLocation.entryType) {
+                        case 'post':
+                          return html`
+                            <posts-context .store=${this.postsStore}>
+                              <attachments-context .store=${this.attachmentsStore}>
+                                <post-detail
+                                  .postHash=${this.weaveClient.renderInfo.view.wal.hrl[1]}
+                                ></post-detail>
+                              </attachments-context>
+                            </posts-context>
+                          `;
+                        default:
+                          throw new Error(
+                            `Unknown entry type ${this.weaveClient.renderInfo.view.recordLocation.entryType}.`
+                          );
+                      }
+                    default:
+                      throw new Error(
+                        `Unknown zome '${this.weaveClient.renderInfo.view.recordLocation.integrityZomeName}'.`
+                      );
+                  }
+                default:
+                  throw new Error(
+                    `Unknown role name '${this.weaveClient.renderInfo.view.recordLocation.roleName}'.`
+                  );
+              }
             }
           case 'creatable':
             switch (this.weaveClient.renderInfo.view.name) {

--- a/example/ui/src/example-applet.ts
+++ b/example/ui/src/example-applet.ts
@@ -82,16 +82,16 @@ export class ExampleApplet extends LitElement {
           case 'block':
             throw new Error('Block view is not implemented.');
           case 'asset':
-            if (!this.weaveClient.renderInfo.view.recordLocation) {
+            if (!this.weaveClient.renderInfo.view.recordInfo) {
               throw new Error(
                 'The example applet does not implement asset views pointing to DNAs instead of Records.'
               );
             } else {
-              switch (this.weaveClient.renderInfo.view.recordLocation.roleName) {
+              switch (this.weaveClient.renderInfo.view.recordInfo.roleName) {
                 case 'forum':
-                  switch (this.weaveClient.renderInfo.view.recordLocation.integrityZomeName) {
+                  switch (this.weaveClient.renderInfo.view.recordInfo.integrityZomeName) {
                     case 'posts_integrity':
-                      switch (this.weaveClient.renderInfo.view.recordLocation.entryType) {
+                      switch (this.weaveClient.renderInfo.view.recordInfo.entryType) {
                         case 'post':
                           return html`
                             <posts-context .store=${this.postsStore}>
@@ -104,17 +104,17 @@ export class ExampleApplet extends LitElement {
                           `;
                         default:
                           throw new Error(
-                            `Unknown entry type ${this.weaveClient.renderInfo.view.recordLocation.entryType}.`
+                            `Unknown entry type ${this.weaveClient.renderInfo.view.recordInfo.entryType}.`
                           );
                       }
                     default:
                       throw new Error(
-                        `Unknown zome '${this.weaveClient.renderInfo.view.recordLocation.integrityZomeName}'.`
+                        `Unknown zome '${this.weaveClient.renderInfo.view.recordInfo.integrityZomeName}'.`
                       );
                   }
                 default:
                   throw new Error(
-                    `Unknown role name '${this.weaveClient.renderInfo.view.recordLocation.roleName}'.`
+                    `Unknown role name '${this.weaveClient.renderInfo.view.recordInfo.roleName}'.`
                   );
               }
             }

--- a/libs/we-applet/src/api.ts
+++ b/libs/we-applet/src/api.ts
@@ -22,7 +22,7 @@ import {
   Hrl,
   WeaveLocation,
   FrameNotification,
-  RecordLocation,
+  RecordInfo,
 } from './types';
 import { postMessage } from './utils.js';
 import { decode, encode } from '@msgpack/msgpack';
@@ -148,7 +148,7 @@ export class AppletServices {
     (this.creatables = {}),
       (this.blockTypes = {}),
       (this.search = async (_appletClient, _appletHash, _weaveServices, _searchFilter) => []),
-      (this.getAssetInfo = async (_appletClient, _wal, _recordLocation) => undefined),
+      (this.getAssetInfo = async (_appletClient, _wal, _recordInfo) => undefined),
       (this.bindAsset = async () => {});
   }
 
@@ -167,7 +167,7 @@ export class AppletServices {
   getAssetInfo: (
     appletClient: AppClient,
     wal: WAL,
-    recordLocation?: RecordLocation,
+    recordInfo?: RecordInfo,
   ) => Promise<AssetInfo | undefined>;
   /**
    * Search in this Applet
@@ -195,7 +195,7 @@ export class AppletServices {
     /**
      * Record location of the dna containing the destination WAL
      */
-    dstRecordLocation?: RecordLocation,
+    dstRecordInfo?: RecordInfo,
   ) => Promise<void>;
 }
 

--- a/libs/we-applet/src/api.ts
+++ b/libs/we-applet/src/api.ts
@@ -22,6 +22,7 @@ import {
   Hrl,
   WeaveLocation,
   FrameNotification,
+  RecordLocation,
 } from './types';
 import { postMessage } from './utils.js';
 import { decode, encode } from '@msgpack/msgpack';
@@ -35,6 +36,12 @@ declare global {
     __isWe__: boolean | undefined;
   }
 }
+
+/**
+ * The null hash is used in case a WAL is to address a DNA only, not specific
+ * DHT content
+ */
+export const NULL_HASH = new Uint8Array(39);
 
 /**
  *
@@ -141,8 +148,7 @@ export class AppletServices {
     (this.creatables = {}),
       (this.blockTypes = {}),
       (this.search = async (_appletClient, _appletHash, _weaveServices, _searchFilter) => []),
-      (this.getAssetInfo = async (_appletClient, _roleName, _integrityZomeName, _entryType, _wal) =>
-        undefined),
+      (this.getAssetInfo = async (_appletClient, _wal, _recordLocation) => undefined),
       (this.bindAsset = async () => {});
   }
 
@@ -160,10 +166,8 @@ export class AppletServices {
    */
   getAssetInfo: (
     appletClient: AppClient,
-    roleName: RoleName,
-    integrityZomeName: ZomeName,
-    entryType: string,
     wal: WAL,
+    recordLocation?: RecordLocation,
   ) => Promise<AssetInfo | undefined>;
   /**
    * Search in this Applet
@@ -189,17 +193,9 @@ export class AppletServices {
      */
     dstWal: WAL,
     /**
-     * role name of the dna containing the destination WAL
+     * Record location of the dna containing the destination WAL
      */
-    dstRoleName: RoleName,
-    /**
-     * integrity zome containing the destination WAL
-     */
-    dstIntegrityZomeName: ZomeName,
-    /**
-     * entry type of the destination WAL
-     */
-    dstEntryType: string,
+    dstRecordLocation?: RecordLocation,
   ) => Promise<void>;
 }
 

--- a/libs/we-applet/src/types.ts
+++ b/libs/we-applet/src/types.ts
@@ -155,10 +155,10 @@ export type AppletView =
   | {
       type: 'asset';
       /**
-       * If the WAL points to a Record (AnyDhtHash) recordLocation will be defined, if the WAL
-       * points to a DNA (i.e. null hash for the AnyDhtHash) then recordLocation is not defined
+       * If the WAL points to a Record (AnyDhtHash) recordInfo will be defined, if the WAL
+       * points to a DNA (i.e. null hash for the AnyDhtHash) then recordInfo is not defined
        */
-      recordLocation?: RecordLocation;
+      recordInfo?: RecordInfo;
       wal: WAL;
     }
   | {
@@ -263,7 +263,7 @@ export type ParentToAppletRequest =
   | {
       type: 'get-applet-asset-info';
       wal: WAL;
-      recordLocation?: RecordLocation;
+      recordInfo?: RecordInfo;
     }
   | {
       type: 'get-block-types';
@@ -272,7 +272,7 @@ export type ParentToAppletRequest =
       type: 'bind-asset';
       srcWal: WAL;
       dstWal: WAL;
-      dstRecordLocation?: RecordLocation;
+      dstRecordInfo?: RecordInfo;
     }
   | {
       type: 'search';
@@ -293,7 +293,7 @@ export type AppletToParentRequest =
       crossApplet: boolean;
     }
   | {
-      type: 'get-record-location';
+      type: 'get-record-info';
       hrl: Hrl;
     }
   | {
@@ -424,7 +424,7 @@ export type ProfilesLocation = {
   profilesRoleName: string;
 };
 
-export type RecordLocation = {
+export type RecordInfo = {
   roleName: string;
   integrityZomeName: string;
   entryType: string;

--- a/libs/we-applet/src/types.ts
+++ b/libs/we-applet/src/types.ts
@@ -14,6 +14,11 @@ import {
 export type AppletHash = EntryHash;
 export type AppletId = EntryHashB64;
 
+/**
+ * Hash of Holohash lenght but all zeroes
+ */
+export type NullHash = Uint8Array;
+
 export type Hrl = [DnaHash, ActionHash | EntryHash];
 export type HrlB64 = [DnaHashB64, ActionHashB64 | EntryHashB64];
 
@@ -149,9 +154,11 @@ export type AppletView =
   | { type: 'block'; block: string; context: any }
   | {
       type: 'asset';
-      roleName: string;
-      integrityZomeName: string;
-      entryType: string;
+      /**
+       * If the WAL points to a Record (AnyDhtHash) recordLocation will be defined, if the WAL
+       * points to a DNA (i.e. null hash for the AnyDhtHash) then recordLocation is not defined
+       */
+      recordLocation?: RecordLocation;
       wal: WAL;
     }
   | {
@@ -255,10 +262,8 @@ export type RenderView =
 export type ParentToAppletRequest =
   | {
       type: 'get-applet-asset-info';
-      roleName: string;
-      integrityZomeName: string;
-      entryType: string;
       wal: WAL;
+      recordLocation?: RecordLocation;
     }
   | {
       type: 'get-block-types';
@@ -267,9 +272,7 @@ export type ParentToAppletRequest =
       type: 'bind-asset';
       srcWal: WAL;
       dstWal: WAL;
-      dstRoleName: string;
-      dstIntegrityZomeName: string;
-      dstEntryType: string;
+      dstRecordLocation?: RecordLocation;
     }
   | {
       type: 'search';
@@ -290,7 +293,7 @@ export type AppletToParentRequest =
       crossApplet: boolean;
     }
   | {
-      type: 'get-hrl-location';
+      type: 'get-record-location';
       hrl: Hrl;
     }
   | {
@@ -421,7 +424,7 @@ export type ProfilesLocation = {
   profilesRoleName: string;
 };
 
-export type HrlLocation = {
+export type RecordLocation = {
   roleName: string;
   integrityZomeName: string;
   entryType: string;

--- a/src/renderer/src/applets/applet-host.ts
+++ b/src/renderer/src/applets/applet-host.ts
@@ -11,7 +11,7 @@ import {
   WeaveServices,
   GroupProfile,
   FrameNotification,
-  RecordLocation,
+  RecordInfo,
 } from '@lightningrodlabs/we-applet';
 import { decodeHashFromBase64, DnaHash, encodeHashToBase64 } from '@holochain/client';
 
@@ -295,18 +295,18 @@ export async function handleAppletIframeMessage(
         };
         return config;
       }
-    case 'get-record-location': {
+    case 'get-record-info': {
       const location = await toPromise(
         mossStore.hrlLocations.get(message.hrl[0]).get(message.hrl[1]),
       );
       if (!location || !location.entryDefLocation) throw new Error('Record not found');
 
-      const recordLocation: RecordLocation = {
+      const recordInfo: RecordInfo = {
         roleName: location.dnaLocation.roleName,
         integrityZomeName: location.entryDefLocation.integrity_zome,
         entryType: location.entryDefLocation.entry_def,
       };
-      return recordLocation;
+      return recordInfo;
     }
     case 'open-view':
       switch (message.request.type) {
@@ -490,23 +490,20 @@ export class AppletHost {
     this.appletId = appletId;
   }
 
-  async getAppletAssetInfo(
-    wal: WAL,
-    recordLocation?: RecordLocation,
-  ): Promise<AssetInfo | undefined> {
+  async getAppletAssetInfo(wal: WAL, recordInfo?: RecordInfo): Promise<AssetInfo | undefined> {
     return this.postMessage({
       type: 'get-applet-asset-info',
       wal,
-      recordLocation,
+      recordInfo,
     });
   }
 
-  bindAsset(srcWal: WAL, dstWal: WAL, dstRecordLocation?: RecordLocation): Promise<void> {
+  bindAsset(srcWal: WAL, dstWal: WAL, dstRecordInfo?: RecordInfo): Promise<void> {
     return this.postMessage({
       type: 'bind-asset',
       srcWal,
       dstWal,
-      dstRecordLocation,
+      dstRecordInfo,
     });
   }
 

--- a/src/renderer/src/layout/views/asset-view.ts
+++ b/src/renderer/src/layout/views/asset-view.ts
@@ -53,16 +53,20 @@ export class AssetView extends LitElement {
     }
   }
 
-  renderGroupView(dnaLocation: DnaLocation, entryTypeLocation: EntryDefLocation) {
+  renderGroupView(dnaLocation: DnaLocation, entryTypeLocation?: EntryDefLocation) {
     return html`<applet-view
         style="flex: 1"
         .appletHash=${dnaLocation.appletHash}
         .view=${{
           type: 'asset',
-          roleName: dnaLocation.roleName,
-          integrityZomeName: entryTypeLocation.integrity_zome,
-          entryType: entryTypeLocation.entry_def,
           wal: this.wal,
+          recordLocation: entryTypeLocation
+            ? {
+                roleName: dnaLocation.roleName,
+                integrityZomeName: entryTypeLocation.integrity_zome,
+                entryType: entryTypeLocation.entry_def,
+              }
+            : undefined,
         }}
       ></applet-view>
       <div id="we-toolbar" class="column toolbar">

--- a/src/renderer/src/layout/views/asset-view.ts
+++ b/src/renderer/src/layout/views/asset-view.ts
@@ -60,7 +60,7 @@ export class AssetView extends LitElement {
         .view=${{
           type: 'asset',
           wal: this.wal,
-          recordLocation: entryTypeLocation
+          recordInfo: entryTypeLocation
             ? {
                 roleName: dnaLocation.roleName,
                 integrityZomeName: entryTypeLocation.integrity_zome,

--- a/utils/applet-iframe/src/index.ts
+++ b/utils/applet-iframe/src/index.ts
@@ -30,7 +30,7 @@ import {
   OpenWalMode,
   CreatableName,
   CreatableType,
-  RecordLocation,
+  RecordInfo,
   NULL_HASH,
 } from '@lightningrodlabs/we-applet';
 
@@ -277,7 +277,7 @@ const handleMessage = async (
       return window.__WEAVE_APPLET_SERVICES__.getAssetInfo(
         appletClient,
         request.wal,
-        request.recordLocation,
+        request.recordInfo,
       );
     case 'get-block-types':
       return window.__WEAVE_APPLET_SERVICES__.blockTypes;
@@ -286,7 +286,7 @@ const handleMessage = async (
         appletClient,
         request.srcWal,
         request.dstWal,
-        request.dstRecordLocation,
+        request.dstRecordInfo,
       );
     case 'search':
       return window.__WEAVE_APPLET_SERVICES__.search(
@@ -463,8 +463,8 @@ async function queryStringToRenderView(s: string): Promise<RenderView> {
           },
         };
       }
-      const recordLocation: RecordLocation = await postMessage({
-        type: 'get-record-location',
+      const recordInfo: RecordInfo = await postMessage({
+        type: 'get-record-info',
         hrl,
       });
       return {
@@ -472,10 +472,10 @@ async function queryStringToRenderView(s: string): Promise<RenderView> {
         view: {
           type: 'asset',
           wal: { hrl, context },
-          recordLocation: {
-            roleName: recordLocation.roleName,
-            integrityZomeName: recordLocation.integrityZomeName,
-            entryType: recordLocation.entryType,
+          recordInfo: {
+            roleName: recordInfo.roleName,
+            integrityZomeName: recordInfo.integrityZomeName,
+            entryType: recordInfo.entryType,
           },
         },
       };


### PR DESCRIPTION
This PR adds affordances to allow addressing dnas (typically cloned cells) with WALs by using a null hash in the HRL.
Information about the record location (entry type, integrity zome name and role name) is only provided to the asset view in case the WAL references a record in a dna, not the dna itself.

