### PR TITLE
Add ReadonlyPeerStatus and onPeerStatusUpdate event

### DIFF
--- a/example/ui/index.html
+++ b/example/ui/index.html
@@ -111,6 +111,7 @@
         };
 
         const weaveClient = await WeaveClient.connect(appletServices);
+
         const provider = document.getElementById('provider');
         provider.weaveClient = weaveClient;
 

--- a/example/ui/src/elements/agent-status.ts
+++ b/example/ui/src/elements/agent-status.ts
@@ -1,0 +1,49 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import { localized } from '@lit/localize';
+import { sharedStyles } from '@holochain-open-dev/elements';
+
+import { PeerStatus, ReadonlyPeerStatusStore } from '@lightningrodlabs/we-applet';
+import { AgentPubKey } from '@holochain/client';
+import { StoreSubscriber } from '@holochain-open-dev/stores';
+import '@holochain-open-dev/profiles/dist/elements/agent-avatar.js';
+import { ProfilesStore, profilesStoreContext } from '@holochain-open-dev/profiles';
+import { consume } from '@lit/context';
+
+@localized()
+@customElement('agent-status')
+export class AgentStatus extends LitElement {
+  @consume({ context: profilesStoreContext, subscribe: true })
+  @property()
+  profilesStore!: ProfilesStore;
+
+  @property()
+  peerStatusStore!: ReadonlyPeerStatusStore;
+
+  @property()
+  agent!: AgentPubKey;
+
+  agentStatus = new StoreSubscriber(
+    this,
+    () => this.peerStatusStore.agentsStatus.get(this.agent),
+    () => [this.peerStatusStore]
+  );
+
+  render() {
+    return html`<agent-avatar
+      .agentPubKey=${this.agent}
+      style="${this.agentStatus.value === PeerStatus.Offline ? 'opacity: 0.4' : ''}"
+    ></agent-avatar> `;
+  }
+
+  static styles = [
+    css`
+      :host {
+        display: flex;
+        flex: 1;
+      }
+    `,
+    sharedStyles,
+  ];
+}

--- a/libs/we-applet/src/types.ts
+++ b/libs/we-applet/src/types.ts
@@ -1,4 +1,6 @@
 import { ProfilesClient } from '@holochain-open-dev/profiles';
+import { Readable } from '@holochain-open-dev/stores';
+import { LazyHoloHashMap } from '@holochain-open-dev/utils';
 import {
   AppClient,
   ActionHash,
@@ -9,6 +11,7 @@ import {
   DnaHashB64,
   CallZomeRequest,
   AppAuthenticationToken,
+  AgentPubKey,
 } from '@holochain/client';
 
 export type AppletHash = EntryHash;
@@ -227,6 +230,7 @@ export type RenderInfo =
       view: AppletView;
       appletClient: AppClient;
       profilesClient: ProfilesClient;
+      peerStatusStore: ReadonlyPeerStatusStore;
       appletHash: AppletHash;
       /**
        * Non-exhaustive array of profiles of the groups the given applet is shared with.
@@ -252,7 +256,7 @@ export type RenderView =
       view: CrossAppletView;
     };
 
-export type ParentToAppletRequest =
+export type ParentToAppletMessage =
   | {
       type: 'get-applet-asset-info';
       roleName: string;
@@ -274,6 +278,10 @@ export type ParentToAppletRequest =
   | {
       type: 'search';
       filter: string;
+    }
+  | {
+      type: 'peer-status-update';
+      payload: PeerStatusUpdate;
     };
 
 export type AppletToParentMessage = {
@@ -426,3 +434,22 @@ export type HrlLocation = {
   integrityZomeName: string;
   entryType: string;
 };
+
+/**
+ *
+ * Events
+ *
+ */
+
+export type UnsubscribeFunction = () => void;
+
+export enum PeerStatus {
+  Online = 'online',
+  Offline = 'offline',
+}
+
+export type PeerStatusUpdate = Array<[AgentPubKey, PeerStatus]>;
+
+export interface ReadonlyPeerStatusStore {
+  agentsStatus: LazyHoloHashMap<Uint8Array, Readable<PeerStatus>>;
+}

--- a/src/renderer/src/applets/applet-host.ts
+++ b/src/renderer/src/applets/applet-host.ts
@@ -6,12 +6,13 @@ import {
   HrlLocation,
   WAL,
   AppletToParentRequest,
-  ParentToAppletRequest,
+  ParentToAppletMessage,
   IframeConfig,
   BlockType,
   WeaveServices,
   GroupProfile,
   FrameNotification,
+  PeerStatusUpdate,
 } from '@lightningrodlabs/we-applet';
 import { decodeHashFromBase64, DnaHash, encodeHashToBase64 } from '@holochain/client';
 
@@ -121,6 +122,9 @@ export async function setupAppletMessageHandler(mossStore: MossStore, openViews:
 
 export function buildHeadlessWeaveClient(mossStore: MossStore): WeaveServices {
   return {
+    onPeerStatusUpdate(_) {
+      return () => undefined;
+    },
     async assetInfo(wal: WAL): Promise<AssetLocationAndInfo | undefined> {
       const maybeCachedInfo = mossStore.weCache.assetInfo.value(wal);
       if (maybeCachedInfo) return maybeCachedInfo;
@@ -530,11 +534,18 @@ export class AppletHost {
     });
   }
 
-  private async postMessage<T>(request: ParentToAppletRequest) {
+  peerStatusUpdate(payload: PeerStatusUpdate) {
+    return this.postMessage({
+      type: 'peer-status-update',
+      payload,
+    });
+  }
+
+  async postMessage<T>(message: ParentToAppletMessage) {
     return new Promise<T>((resolve, reject) => {
       const { port1, port2 } = new MessageChannel();
 
-      this.iframe.contentWindow!.postMessage(request, '*', [port2]);
+      this.iframe.contentWindow!.postMessage(message, '*', [port2]);
 
       port1.onmessage = (m) => {
         if (m.data.type === 'success') {

--- a/src/renderer/src/elements/group-sidebar-button.ts
+++ b/src/renderer/src/elements/group-sidebar-button.ts
@@ -59,7 +59,7 @@ export class GroupSidebarButton extends LitElement {
   }
 
   firstUpdated() {
-    this._unsubscribe = this._onlineAgents.store.subscribe(async (value) => {
+    this._unsubscribe = this._onlineAgents.store.subscribe((value) => {
       // TODO emit event if first agent comes online
       if (value.status === 'complete') {
         if (value.value.length > 0) {

--- a/src/renderer/src/elements/group-sidebar-button.ts
+++ b/src/renderer/src/elements/group-sidebar-button.ts
@@ -59,7 +59,7 @@ export class GroupSidebarButton extends LitElement {
   }
 
   firstUpdated() {
-    this._unsubscribe = this._onlineAgents.store.subscribe((value) => {
+    this._unsubscribe = this._onlineAgents.store.subscribe(async (value) => {
       // TODO emit event if first agent comes online
       if (value.status === 'complete') {
         if (value.value.length > 0) {


### PR DESCRIPTION
* adds a `ReadonlyPeerStatusStore` to `RenderInfo` in the `applet-view` case that can be used by tools to display peer status information
* adds a `WeaveClient.onPeerStatusUpdate(callback)` event handler that can be used by tools to define custom logic upon updates to peer's status.