### PR TITLE
Add group meta data entries

### DIFF
--- a/dnas/group/zomes/coordinator/group/src/group_meta_data.rs
+++ b/dnas/group/zomes/coordinator/group/src/group_meta_data.rs
@@ -1,36 +1,36 @@
 use group_integrity::*;
 use hdk::prelude::*;
 #[hdk_extern]
-pub fn set_group_profile(group_profile: GroupProfile) -> ExternResult<Record> {
-    let group_profile_hash = create_entry(&EntryTypes::GroupProfile(group_profile.clone()))?;
-    let record = get(group_profile_hash.clone(), GetOptions::default())?.ok_or(wasm_error!(
+pub fn set_group_meta_data(group_meta_data: GroupMetaData) -> ExternResult<Record> {
+    let group_meta_data_hash = create_entry(&EntryTypes::GroupMetaData(group_meta_data.clone()))?;
+    let record = get(group_meta_data_hash.clone(), GetOptions::default())?.ok_or(wasm_error!(
         WasmErrorInner::Guest("Could not find the newly created GroupProfile".to_string())
     ))?;
-    let path = Path::from("all_group_profiles");
+    let path = Path::from(group_meta_data.name.as_str());
     create_link(
         path.path_entry_hash()?,
-        group_profile_hash.clone(),
-        LinkTypes::AllGroupProfiles,
+        group_meta_data_hash.clone(),
+        LinkTypes::GroupMetaDataToAnchor,
         (),
     )?;
     Ok(record)
 }
 
 #[hdk_extern]
-pub fn get_group_profile() -> ExternResult<Option<Record>> {
-    let path = Path::from("all_group_profiles");
+pub fn get_group_meta_data(name: String) -> ExternResult<Option<Record>> {
+    let path = Path::from(name.as_str());
 
     let links = get_links(
-        GetLinksInputBuilder::try_new(path.path_entry_hash()?, LinkTypes::AllGroupProfiles)?
+        GetLinksInputBuilder::try_new(path.path_entry_hash()?, LinkTypes::GroupMetaDataToAnchor)?
             .build(),
     )?;
 
-    let latest_group_info_link = links
+    let latest_group_meta_data_link = links
         .into_iter()
         .max_by(|link_a, link_b| link_b.timestamp.cmp(&link_a.timestamp));
 
     // This might be brittle in case the link has propagated but not yet the entry
-    match latest_group_info_link {
+    match latest_group_meta_data_link {
         None => Ok(None),
         Some(link) => {
             let record = get(

--- a/dnas/group/zomes/coordinator/group/src/lib.rs
+++ b/dnas/group/zomes/coordinator/group/src/lib.rs
@@ -1,20 +1,18 @@
-pub mod all_group_profiles;
-
-pub mod group_profile;
-
 pub mod all_applets;
-
-pub mod applet;
-
+pub mod all_group_profiles;
 pub mod all_steward_permissions;
-
+pub mod applet;
+pub mod group_meta_data;
+pub mod group_profile;
 pub mod steward_permission;
 use group_integrity::*;
 use hdk::prelude::*;
+
 #[hdk_extern]
 pub fn init() -> ExternResult<InitCallbackResult> {
     Ok(InitCallbackResult::Pass)
 }
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
 pub enum Signal {
@@ -41,6 +39,7 @@ pub enum Signal {
         original_app_entry: EntryTypes,
     },
 }
+
 #[hdk_extern(infallible)]
 pub fn post_commit(committed_actions: Vec<SignedActionHashed>) {
     for action in committed_actions {
@@ -49,6 +48,7 @@ pub fn post_commit(committed_actions: Vec<SignedActionHashed>) {
         }
     }
 }
+
 fn signal_action(action: SignedActionHashed) -> ExternResult<()> {
     match action.hashed.content.clone() {
         Action::CreateLink(create_link) => {
@@ -115,6 +115,7 @@ fn signal_action(action: SignedActionHashed) -> ExternResult<()> {
         _ => Ok(()),
     }
 }
+
 fn get_entry_for_action(action_hash: &ActionHash) -> ExternResult<Option<EntryTypes>> {
     let record = match get_details(action_hash.clone(), GetOptions::default())? {
         Some(Details::Record(record_details)) => record_details.record,

--- a/dnas/group/zomes/integrity/group/src/applet.rs
+++ b/dnas/group/zomes/integrity/group/src/applet.rs
@@ -49,7 +49,7 @@ pub fn validate_delete_applet(
 /// 1. Link must point away from the all_applets anchor
 /// 2. Link must point to an entry hash
 pub fn validate_create_link_all_applets(
-    action: CreateLink,
+    _action: CreateLink,
     base_address: AnyLinkableHash,
     target_address: AnyLinkableHash,
     _tag: LinkTag,

--- a/dnas/group/zomes/integrity/group/src/group_meta_data.rs
+++ b/dnas/group/zomes/integrity/group/src/group_meta_data.rs
@@ -1,0 +1,96 @@
+use crate::validate_steward_permission;
+use hdi::prelude::*;
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct GroupMetaData {
+    pub permission_hash: Option<ActionHash>,
+    pub name: String,
+    pub data: String,
+}
+pub fn validate_create_group_meta_data(
+    action: EntryCreationAction,
+    group_meta_data: GroupMetaData,
+) -> ExternResult<ValidateCallbackResult> {
+    validate_steward_permission(
+        action.author(),
+        group_meta_data.permission_hash,
+        action.timestamp(),
+        true,
+    )
+}
+pub fn validate_update_group_meta_data(
+    _action: Update,
+    _group_meta_data: GroupMetaData,
+    _original_action: EntryCreationAction,
+    _original_group_meta_data: GroupMetaData,
+) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(String::from(
+        "GroupMetaData entries cannot be updated",
+    )))
+}
+pub fn validate_delete_group_meta_data(
+    _action: Delete,
+    _original_action: EntryCreationAction,
+    _original_group_meta_data: GroupMetaData,
+) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(String::from(
+        "GroupMetaData entries cannot be deleted",
+    )))
+}
+
+/// Rules
+/// 1. Link must point away from the correctly named anchor
+/// 2. Link must point to a valid GroupMetaData entry
+/// 3. The creator of the link must be the one that created the GroupMetaData entry
+pub fn validate_create_link_group_meta_data_to_anchor(
+    action: CreateLink,
+    base_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
+    _tag: LinkTag,
+) -> ExternResult<ValidateCallbackResult> {
+    // Check the entry type for the given action hash
+    let action_hash =
+        target_address
+            .into_action_hash()
+            .ok_or(wasm_error!(WasmErrorInner::Guest(
+                "No action hash associated with link".to_string()
+            )))?;
+    let record = must_get_valid_record(action_hash)?;
+    let group_meta_data: GroupMetaData = record
+        .entry()
+        .to_app_option()
+        .map_err(|e| wasm_error!(e))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(
+            "Linked action must reference an entry".to_string()
+        )))?;
+
+    // Check that base address is pointing away from the correctly named anchor
+    let base_address_entry_hash = EntryHash::try_from(base_address).map_err(|_| {
+        wasm_error!(WasmErrorInner::Guest(
+            "Base address is not an entry hash".into()
+        ))
+    })?;
+    let path = Path::from(group_meta_data.name.as_str());
+    if path.path_entry_hash()? != base_address_entry_hash {
+        return Ok(ValidateCallbackResult::Invalid(
+            "GroupMetaDataToAnchor link is not pointing away from the correctly named anchor"
+                .into(),
+        ));
+    }
+
+    if record.action().author() != &action.author {
+        return Ok(ValidateCallbackResult::Invalid("Only the creator of a GroupMetaData entry can create a link from the GroupMetaData its corresponding anchor".into()));
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+pub fn validate_delete_link_group_meta_data_to_anchor(
+    _action: DeleteLink,
+    _original_action: CreateLink,
+    _base: AnyLinkableHash,
+    _target: AnyLinkableHash,
+    _tag: LinkTag,
+) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(
+        "Links to group meta data entries cannot be deleted.".into(),
+    ))
+}

--- a/src/renderer/src/groups/group-client.ts
+++ b/src/renderer/src/groups/group-client.ts
@@ -14,6 +14,7 @@ import { AppletHash, GroupProfile } from '@lightningrodlabs/we-applet';
 import {
   Applet,
   AppletAgent,
+  GroupMetaData,
   JoinAppletInput,
   PermissionType,
   PrivateAppletEntry,
@@ -195,6 +196,16 @@ export class GroupClient {
 
   async getAllAgentPermissionTypes(): Promise<Array<[AgentPubKey, PermissionType]> | undefined> {
     return this.callZome('get_all_agent_permission_types', null);
+  }
+
+  async getGroupMetaData(name: string): Promise<EntryRecord<GroupMetaData> | undefined> {
+    const record = await this.callZome('get_group_meta_data', name);
+    return record ? new EntryRecord(record) : undefined;
+  }
+
+  async setGroupMetaData(metaData: GroupMetaData): Promise<EntryRecord<GroupMetaData>> {
+    const record = await this.callZome('set_group_meta_data', metaData);
+    return new EntryRecord(record);
   }
 
   private callZome(fn_name: string, payload: any) {

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -65,6 +65,12 @@ export type GroupProfile = {
   meta_data?: string;
 };
 
+export type GroupMetaData = {
+  permission_hash?: ActionHash;
+  name: string;
+  data: string;
+};
+
 export type Applet = {
   /**
    * ActionHash of the StewardPermission based on which the Applet entry has been created


### PR DESCRIPTION
Adds an entry type to groups for named meta data which can be used e.g. to populate the group home page with WALs etc.